### PR TITLE
Bug Fixed: The Url That Should Lead To User Comments, Now Does So Accordingly.

### DIFF
--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -57,11 +57,8 @@ const routes = [
         component: Wallet,
       },
       {
-        path: '/:category?/@:author/:permlink',
-        component: Post,
-      },
-      {
         path: '/(editor|main-editor|teardrops|untalented|fanlove|ulog-ned|ulog-surpassinggoogle|ulog-diy|ulog-howto|ulog-quotes)',
+        exact: true,
         component: Editor,
       },
       {
@@ -136,6 +133,11 @@ const routes = [
         exact: true,
         component: Discover,
       },
+      {
+        path: '/:category?/@:author/:permlink',
+        component: Post,
+      },
+
       {
         path: '/search',
         component: Search,

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -57,6 +57,10 @@ const routes = [
         component: Wallet,
       },
       {
+        path: '/:category?/@:author/:permlink',
+        component: Post,
+      },
+      {
         path: '/(editor|main-editor|teardrops|untalented|fanlove|ulog-ned|ulog-surpassinggoogle|ulog-diy|ulog-howto|ulog-quotes)',
         component: Editor,
       },
@@ -131,10 +135,6 @@ const routes = [
         path: '/discover',
         exact: true,
         component: Discover,
-      },
-      {
-        path: '/:category?/@:author/:permlink',
-        component: Post,
       },
       {
         path: '/search',


### PR DESCRIPTION
### Fixes

Normally, ulogs.org/@username/comments should lead to user comments, this wasn't the case due to a bug. This has been fixed in this merge

