### PR TITLE
Don't let users enable beta option

### DIFF
--- a/src/client/components/Utils/Redirect.js
+++ b/src/client/components/Utils/Redirect.js
@@ -4,12 +4,6 @@ import { connect } from 'react-redux';
 import { getUseBeta } from '../../reducers';
 
 const Redirect = ({ useBeta }) => {
-  if (typeof window !== 'undefined' && window.location.host === 'ulogs.org' && useBeta) {
-    const url = window.location.href.split('/');
-    url[2] = 'staging.ulogs.org';
-    window.location.replace(url.join('/'));
-  }
-
   return <div />;
 };
 

--- a/src/client/settings/Settings.js
+++ b/src/client/settings/Settings.js
@@ -76,9 +76,9 @@ export default class Settings extends React.Component {
     useBeta: false,
     upvoteSetting: true,
     exitPageSetting: true,
-    reload: () => {},
-    saveSettings: () => {},
-    notify: () => {},
+    reload: () => { },
+    saveSettings: () => { },
+    notify: () => { },
   };
 
   constructor(props) {
@@ -163,7 +163,7 @@ export default class Settings extends React.Component {
           this.props.intl.formatMessage({ id: 'saved', defaultMessage: 'Saved' }),
           'success',
         ),
-      );
+    );
   };
 
   handleLocaleChange = locale => this.setState({ locale });
@@ -233,180 +233,164 @@ export default class Settings extends React.Component {
             {reloading ? (
               <Loading center={false} />
             ) : (
-              <div className="Settings">
-                <div className="Settings__section">
-                  <h3>
-                    <FormattedMessage id="voting_power" defaultMessage="Voting Power" />
-                  </h3>
-                  <p>
-                    <FormattedMessage
-                      id="voting_power_info"
-                      defaultMessage="You can enable Voting Power slider to specify exact percentage of your Voting Power to use for like."
-                    />
-                  </p>
-                  <Radio.Group
-                    defaultValue={initialVotingPower}
-                    value={votingPower}
-                    onChange={this.handleVotingPowerChange}
-                  >
-                    <Radio value="off">
-                      <FormattedMessage id="voting_power_off" defaultMessage="Disable slider" />
-                    </Radio>
-                    <Radio value="on">
-                      <FormattedMessage id="voting_power_on" defaultMessage="Enable slider" />
-                    </Radio>
-                  </Radio.Group>
-                </div>
-                <div className="Settings__section">
-                  <h3>
-                    <FormattedMessage id="vote_percent" defaultMessage="Default vote percent" />
-                  </h3>
-                  <p>
-                    <FormattedMessage
-                      id="vote_percent_info"
-                      defaultMessage="You can select your default vote value. It will be used as default value in voting slider and as value used for vote when voting slider is disabled."
-                    />
-                  </p>
-                  <div className="Settings__section__component">
-                    <RawSlider
-                      initialValue={this.state.votePercent}
-                      onChange={this.handleVotePercentChange}
-                    />
-                  </div>
-                </div>
-                <div className="Settings__section">
-                  <h3>
-                    <FormattedMessage id="language" defaultMessage="Language" />
-                  </h3>
-                  <p>
-                    <FormattedMessage
-                      id="language_info"
-                      defaultMessage="What language do you want to use on Busy?"
-                    />
-                  </p>
-                  <Select
-                    defaultValue={initialLocale}
-                    value={locale}
-                    style={{ width: '100%', maxWidth: 240 }}
-                    onChange={this.handleLocaleChange}
-                  >
-                    {languageOptions}
-                  </Select>
-                </div>
-                <div className="Settings__section">
-                  <h3>
-                    <FormattedMessage id="nsfw_posts" defaultMessage="NSFW Posts" />
-                  </h3>
-                  <p>
-                    <FormattedMessage
-                      id="display_nsfw_posts_details"
-                      defaultMessage="You can enable all posts tagged with NSFW to be shown as default."
-                    />
-                  </p>
-                  <div className="Settings__section__checkbox">
-                    <Checkbox
-                      name="nsfw_posts"
-                      defaultChecked={initialShowNSFWPosts}
-                      checked={showNSFWPosts}
-                      onChange={this.handleShowNSFWPosts}
-                    >
+                <div className="Settings">
+                  <div className="Settings__section">
+                    <h3>
+                      <FormattedMessage id="voting_power" defaultMessage="Voting Power" />
+                    </h3>
+                    <p>
                       <FormattedMessage
-                        id="display_nsfw_posts"
-                        defaultMessage="Display NSFW Posts"
+                        id="voting_power_info"
+                        defaultMessage="You can enable Voting Power slider to specify exact percentage of your Voting Power to use for like."
                       />
-                    </Checkbox>
-                  </div>
-                </div>
-                <div className="Settings__section">
-                  <h3>
-                    <FormattedMessage id="rewrite_links" defaultMessage="Rewrite links" />
-                  </h3>
-                  <p>
-                    <FormattedMessage
-                      id="rewrite_links_details"
-                      defaultMessage="You can enable this option to replace Steemit.com links with Busy.org links."
-                    />
-                  </p>
-                  <div className="Settings__section__checkbox">
-                    <Checkbox
-                      name="rewrite_links"
-                      checked={rewriteLinks}
-                      onChange={this.handleRewriteLinksChange}
+                    </p>
+                    <Radio.Group
+                      defaultValue={initialVotingPower}
+                      value={votingPower}
+                      onChange={this.handleVotingPowerChange}
                     >
+                      <Radio value="off">
+                        <FormattedMessage id="voting_power_off" defaultMessage="Disable slider" />
+                      </Radio>
+                      <Radio value="on">
+                        <FormattedMessage id="voting_power_on" defaultMessage="Enable slider" />
+                      </Radio>
+                    </Radio.Group>
+                  </div>
+                  <div className="Settings__section">
+                    <h3>
+                      <FormattedMessage id="vote_percent" defaultMessage="Default vote percent" />
+                    </h3>
+                    <p>
+                      <FormattedMessage
+                        id="vote_percent_info"
+                        defaultMessage="You can select your default vote value. It will be used as default value in voting slider and as value used for vote when voting slider is disabled."
+                      />
+                    </p>
+                    <div className="Settings__section__component">
+                      <RawSlider
+                        initialValue={this.state.votePercent}
+                        onChange={this.handleVotePercentChange}
+                      />
+                    </div>
+                  </div>
+                  <div className="Settings__section">
+                    <h3>
+                      <FormattedMessage id="language" defaultMessage="Language" />
+                    </h3>
+                    <p>
+                      <FormattedMessage
+                        id="language_info"
+                        defaultMessage="What language do you want to use on Busy?"
+                      />
+                    </p>
+                    <Select
+                      defaultValue={initialLocale}
+                      value={locale}
+                      style={{ width: '100%', maxWidth: 240 }}
+                      onChange={this.handleLocaleChange}
+                    >
+                      {languageOptions}
+                    </Select>
+                  </div>
+                  <div className="Settings__section">
+                    <h3>
+                      <FormattedMessage id="nsfw_posts" defaultMessage="NSFW Posts" />
+                    </h3>
+                    <p>
+                      <FormattedMessage
+                        id="display_nsfw_posts_details"
+                        defaultMessage="You can enable all posts tagged with NSFW to be shown as default."
+                      />
+                    </p>
+                    <div className="Settings__section__checkbox">
+                      <Checkbox
+                        name="nsfw_posts"
+                        defaultChecked={initialShowNSFWPosts}
+                        checked={showNSFWPosts}
+                        onChange={this.handleShowNSFWPosts}
+                      >
+                        <FormattedMessage
+                          id="display_nsfw_posts"
+                          defaultMessage="Display NSFW Posts"
+                        />
+                      </Checkbox>
+                    </div>
+                  </div>
+                  <div className="Settings__section">
+                    <h3>
                       <FormattedMessage id="rewrite_links" defaultMessage="Rewrite links" />
-                    </Checkbox>
+                    </h3>
+                    <p>
+                      <FormattedMessage
+                        id="rewrite_links_details"
+                        defaultMessage="You can enable this option to replace Steemit.com links with Busy.org links."
+                      />
+                    </p>
+                    <div className="Settings__section__checkbox">
+                      <Checkbox
+                        name="rewrite_links"
+                        checked={rewriteLinks}
+                        onChange={this.handleRewriteLinksChange}
+                      >
+                        <FormattedMessage id="rewrite_links" defaultMessage="Rewrite links" />
+                      </Checkbox>
+                    </div>
                   </div>
-                </div>
-                <div className="Settings__section">
-                  <h3>
-                    <FormattedMessage id="use_beta" defaultMessage="Use Busy beta" />
-                  </h3>
-                  <p>
-                    <FormattedMessage
-                      id="use_beta_details"
-                      defaultMessage="You can enable this option to use Busy beta by default."
-                    />
-                  </p>
-                  <div className="Settings__section__checkbox">
-                    <Checkbox name="use_beta" checked={useBeta} onChange={this.handleUseBetaChange}>
-                      <FormattedMessage id="use_beta" defaultMessage="Use Busy beta" />
-                    </Checkbox>
-                  </div>
-                </div>
-                <div className="Settings__section">
-                  <h3>
-                    <FormattedMessage id="upvote_setting" defaultMessage="Like my posts" />
-                  </h3>
-                  <p>
-                    <FormattedMessage
-                      id="upvote_setting_details"
-                      defaultMessage="Enable this option to automatically like your own posts."
-                    />
-                  </p>
-                  <div className="Settings__section__checkbox">
-                    <Checkbox
-                      name="upvote_setting"
-                      checked={upvoteSetting}
-                      onChange={this.handleUpvoteSettingChange}
-                    >
+                  <div className="Settings__section">
+                    <h3>
                       <FormattedMessage id="upvote_setting" defaultMessage="Like my posts" />
-                    </Checkbox>
+                    </h3>
+                    <p>
+                      <FormattedMessage
+                        id="upvote_setting_details"
+                        defaultMessage="Enable this option to automatically like your own posts."
+                      />
+                    </p>
+                    <div className="Settings__section__checkbox">
+                      <Checkbox
+                        name="upvote_setting"
+                        checked={upvoteSetting}
+                        onChange={this.handleUpvoteSettingChange}
+                      >
+                        <FormattedMessage id="upvote_setting" defaultMessage="Like my posts" />
+                      </Checkbox>
+                    </div>
                   </div>
-                </div>
-                <div className="Settings__section">
-                  <h3>
-                    <FormattedMessage id="enable_exit_page" defaultMessage="Enable exit page" />
-                  </h3>
-                  <p>
-                    <FormattedMessage
-                      id="enable_exit_page_details"
-                      defaultMessage="Enable this option to use the exit page when clicking on an external link."
-                    />
-                  </p>
-                  <div className="Settings__section__checkbox">
-                    <Checkbox
-                      name="exit_page_setting"
-                      checked={exitPageSetting}
-                      onChange={this.handleExitPageSettingChange}
-                    >
+                  <div className="Settings__section">
+                    <h3>
                       <FormattedMessage id="enable_exit_page" defaultMessage="Enable exit page" />
-                    </Checkbox>
+                    </h3>
+                    <p>
+                      <FormattedMessage
+                        id="enable_exit_page_details"
+                        defaultMessage="Enable this option to use the exit page when clicking on an external link."
+                      />
+                    </p>
+                    <div className="Settings__section__checkbox">
+                      <Checkbox
+                        name="exit_page_setting"
+                        checked={exitPageSetting}
+                        onChange={this.handleExitPageSettingChange}
+                      >
+                        <FormattedMessage id="enable_exit_page" defaultMessage="Enable exit page" />
+                      </Checkbox>
+                    </div>
+                  </div>
+                  <Action primary big loading={loading} onClick={this.handleSave}>
+                    <FormattedMessage id="save" defaultMessage="Save" />
+                  </Action>
+                  <div className="Settings__version">
+                    <p>
+                      <FormattedMessage
+                        id="version"
+                        defaultMessage="Version: {version}"
+                        values={{ version: packageJson.version }}
+                      />
+                    </p>
                   </div>
                 </div>
-                <Action primary big loading={loading} onClick={this.handleSave}>
-                  <FormattedMessage id="save" defaultMessage="Save" />
-                </Action>
-                <div className="Settings__version">
-                  <p>
-                    <FormattedMessage
-                      id="version"
-                      defaultMessage="Version: {version}"
-                      values={{ version: packageJson.version }}
-                    />
-                  </p>
-                </div>
-              </div>
-            )}
+              )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes #98

### Changes

Summary of changes you made.

* Option to enable beta is removed
* Users aren't redirected if they have beta enabled

### Test plan

Explain how to test changes you made.

* [ ] Go to settings page
* [ ] Try (and fail) to enable beta mode