### PR TITLE
updated ulog overseers

### DIFF
--- a/src/client/app/Sidebar/RightSidebar.js
+++ b/src/client/app/Sidebar/RightSidebar.js
@@ -13,6 +13,7 @@ import {
 import { checkWitnessVote } from '../../helpers/voteHelpers';
 import { updateRecommendations } from '../../user/userActions';
 import InterestingUloggersWithAPI from '../../components/Sidebar/InterestingUloggersWithAPI';
+import OverseeingUloggers from '../../components/Sidebar/OverseeingUloggers';
 import UlogStories from '../../components/Sidebar/UlogStories';
 import SignUp from '../../components/Sidebar/SignUp';
 import WitnessVote from '../../components/Sidebar/WitnessVote';
@@ -87,7 +88,7 @@ export default class RightSidebar extends React.Component {
       category.match(
         /^(ulog-quotes|ulog-howto|ulog-diy|ulog-surpassinggoogle|teardrops|untalented|ulog-ned|ulography|ulog-gratefulvibes|ulog-resolutions|ulog-memes|ulog-blocktrades|ulog-showerthoughts|ulog-snookmademedoit|ulog-utopian|ulog-thejohalfiles|ulogifs|ulog-surfyogi|ulog-bobbylee|ulog-stellabelle|ulog-sweetsssj|ulog-dimimp|ulog-teamsteem|ulog-kusknee|ulog-papapepper|ulog-steemjet)$/,
       );
-    console.log('displayUlogCaption', displayUlogCaption);
+
     return (
       <div>
         {!authenticated && <SignUp />}
@@ -128,7 +129,7 @@ export default class RightSidebar extends React.Component {
                       followingList={followingList}
                       isFetchingFollowingList={isFetchingFollowingList}
                     />
-                    <InterestingUloggersWithAPI
+                    <OverseeingUloggers
                       authenticatedUser={authenticatedUser}
                       followingList={followingList}
                       isFetchingFollowingList={isFetchingFollowingList}

--- a/src/client/components/Sidebar/OverseeingUloggers.js
+++ b/src/client/components/Sidebar/OverseeingUloggers.js
@@ -4,14 +4,14 @@ import { Link, withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { Collapse } from 'antd';
 import _ from 'lodash';
-import User from './User';
+import UlogOverseer from './UlogOverseer';
 import Loading from '../../components/Icon/Loading';
 import steemAPI from '../../steemAPI';
 import './InterestingPeople.less';
 import './SidebarContentBlock.less';
 
 @withRouter
-class InterestingUloggersWithAPI extends React.Component {
+class OverseeingUloggers extends React.Component {
   static propTypes = {
     isFetchingFollowingList: PropTypes.bool.isRequired,
   };
@@ -32,58 +32,30 @@ class InterestingUloggersWithAPI extends React.Component {
       noUsers: false,
     };
 
-    this.getCertifiedUloggers = this.getCertifiedUloggers.bind(this);
+    this.getUlogOverseers = this.getUlogOverseers.bind(this);
   }
 
   componentDidMount() {
     if (!this.props.isFetchingFollowingList) {
-      this.getCertifiedUloggers();
+      this.getUlogOverseers();
     }
   }
 
   componentWillReceiveProps(nextProps) {
     if (!nextProps.isFetchingFollowingList) {
-      this.getCertifiedUloggers();
+      this.getUlogOverseers();
     }
   }
 
-  getCertifiedUloggers() {
-    steemAPI
-      .sendAsync('call', ['condenser_api', 'get_following', ['uloggers', '', 'blog', 100]])
-      .then(result => {
-        const userNames = _.sortBy(result, 'following')
-          .map(user => {
-            let name = _.get(user, 0);
-
-            if (_.isEmpty(name)) {
-              name = _.get(user, 'following');
-            }
-            return {
-              name,
-            };
-          });
-        if (userNames.length > 0) {
-          this.setState({
-            userNames,
-          });
-        } else {
-          this.setState({
-            noUsers: true,
-          });
-        }
-      })
-      .then(() => {
-        const uloggers = this.state.userNames.map(user => {
-            return user.name;
-          });
-        steemAPI.sendAsync('get_accounts', [uloggers]).then(users =>
-          this.setState({
-            users,
-            loading: false,
-            noUsers: false,
-          })
-        );
-     })
+  getUlogOverseers() {
+    steemAPI.sendAsync('get_accounts', [["ulogs"]])
+      .then(users =>
+        this.setState({
+          users,
+          loading: false,
+          noUsers: false,
+        })
+      )
      .catch(() => {
         this.setState({
           noUsers: true,
@@ -116,7 +88,7 @@ class InterestingUloggersWithAPI extends React.Component {
               <i className="iconfont icon-group SidebarContentBlock__icon" />{' '}
               <FormattedMessage id="overseeing_uloggers" defaultMessage="Overseeing Uloggers" />
               <button
-                onClick={this.getCertifiedUloggers}
+                onClick={this.getUlogOverseers}
                 className="InterestingPeople__button-refresh"
               >
                 <i
@@ -132,17 +104,9 @@ class InterestingUloggersWithAPI extends React.Component {
         >
           <div
             className="SidebarContentBlock__content"
-            style={{ textAlign: 'center', overflowY: 'auto', height: '300px', paddingLeft: 0 }}
+            style={{ textAlign: 'center', overflowY: 'auto', height: 'auto', paddingLeft: 0 }}
           >
-            {users && users.map(user => <User key={user.name} user={user} />)}
-            <h4 className="InterestingPeople__more">
-              <Link to={'/discover'}>
-                <FormattedMessage
-                  id="discover_more_people"
-                  defaultMessage="Discover More Uloggers"
-                />
-              </Link>
-            </h4>
+            {users && users.map(user => <UlogOverseer key={user.name} user={user} />)}
           </div>
         </Collapse.Panel>
       </Collapse>
@@ -150,4 +114,4 @@ class InterestingUloggersWithAPI extends React.Component {
   }
 }
 
-export default InterestingUloggersWithAPI;
+export default OverseeingUloggers;

--- a/src/client/components/Sidebar/UlogOverseer.js
+++ b/src/client/components/Sidebar/UlogOverseer.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import Avatar from '../Avatar';
+import FollowButton from '../../widgets/FollowButton';
+import DelegateButton from '../StoryFooter/DelegateButton';
+import './User.less';
+
+const UlogOverseer = ({ user }) => (
+  <div key={user.name} className="User">
+    <div className="User__top">
+      <div className="User__links">
+        <Link to={`/@${user.name}`}>
+          <Avatar username={user.name} size={34} />
+        </Link>
+        <Link to={`/@${user.name}`} title={user.name} className="User__name">
+          <span className="username">{user.name}</span>
+        </Link>
+      </div>
+      <DelegateButton
+        post={{
+          author: user.name,
+        }}
+      />
+    </div>
+  </div>
+);
+
+UlogOverseer.propTypes = {
+  user: PropTypes.shape().isRequired,
+};
+
+export default UlogOverseer;

--- a/src/client/locales/default.json
+++ b/src/client/locales/default.json
@@ -175,6 +175,7 @@
   "sort_author_reputation": "Reputation",
   "trending_topics": "Trending Hashtags",
   "favorite_topics": "Favorite Hashtags",
+  "overseeing_uloggers": "Overseeing Uloggers",
   "interesting_people": "Interesting People",
   "top_reblogged_users": "Top Reblogged Users",
   "latest_comments": "Latest Comments",


### PR DESCRIPTION
Fix for issue #202 

`2\. The left column currently titled 'interesting people' should be called 'overseeing uloggers' and should be completed in relation to the screenshot-guide shown earlier. Also, this column should currently only display the @ulogs account. Then, kindly remove the 'follow' button, leaving only the 'delegate' button. Also this 'overseeing uloggers' column should be placed right under the video-embed column.`